### PR TITLE
Add req.url to notFound handler message

### DIFF
--- a/lib/not-found-handler.js
+++ b/lib/not-found-handler.js
@@ -2,6 +2,6 @@ const errors = require('./index');
 
 module.exports = function () {
   return function (req, res, next) {
-    next(new errors.NotFound('Page not found'));
+    next(new errors.NotFound('Page not found | Requested page/route: ' + req.url));
   };
 };


### PR DESCRIPTION
Solve unhelpful log message whenever a page is not found.