### PR TITLE
Add a verbose flag to notFound handler

### DIFF
--- a/lib/not-found-handler.js
+++ b/lib/not-found-handler.js
@@ -1,7 +1,9 @@
 const errors = require('./index');
 
-module.exports = function () {
+module.exports = function ({ verbose = false } = {}) {
   return function (req, res, next) {
-    next(new errors.NotFound('Page not found | Requested page/route: ' + req.url));
+    const { url } = req;
+    const message = `Page not found${verbose ? ': ' + url : ''}`;
+    next(new errors.NotFound(message, { url }));
   };
 };

--- a/test/not-found-handler.test.js
+++ b/test/not-found-handler.test.js
@@ -23,8 +23,29 @@ describe('not-found-handler', () => {
   });
 
   it('returns NotFound error', done => {
-    handler()({}, {}, function (error) {
+    handler()({
+      url: 'some/where',
+      headers: {}
+    }, {}, function (error) {
       expect(error instanceof errors.NotFound).to.equal(true);
+      expect(error.message).to.equal('Page not found');
+      expect(error.data).to.deep.equal({
+        url: 'some/where'
+      });
+      done();
+    });
+  });
+
+  it('returns NotFound error with URL when verbose', done => {
+    handler({ verbose: true })({
+      url: 'some/where',
+      headers: {}
+    }, {}, function (error) {
+      expect(error instanceof errors.NotFound).to.equal(true);
+      expect(error.message).to.equal('Page not found: some/where');
+      expect(error.data).to.deep.equal({
+        url: 'some/where'
+      });
       done();
     });
   });


### PR DESCRIPTION
To keep things backwards compatible.

Follow-up on https://github.com/feathersjs/errors/pull/105